### PR TITLE
device-tree: update license (fix obsolete license warning)

### DIFF
--- a/recipes-bsp/device-tree/device-tree.bbappend
+++ b/recipes-bsp/device-tree/device-tree.bbappend
@@ -1,6 +1,6 @@
 DESCRIPTION = "Device Tree generation and packaging for BSP Device Trees using DTG from Xilinx"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://xadcps/data/xadcps.mdd;md5=f7fa1bfdaf99c7182fc0d8e7fd28e04a"
 
 require recipes-bsp/device-tree/device-tree.inc


### PR DESCRIPTION
Use correct GPLv2 LICENSE tag to fix an obsolete license warning.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>